### PR TITLE
Change assumptions about repo owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Register for this course to get the starter files needed to build your Learning 
 - create responses
 - publish a course to GitHub Learning Lab
 
-**Note:** You'll need to be a owner of this organization in order to publish the course you create.
+**Note:** In order to publish your final course, you'll need to transfer it to your designated Learning Lab organization.

--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,8 @@ steps:
       right: assigned
     - type: respond
       with: how-to-publish.md
+      data: 
+        url: '%payload.repository.html_url%/fork'
     - type: respond
       with: change-mind.md
   - type: createPullRequest
@@ -571,8 +573,11 @@ steps:
     title: Publish your course
     body: 14.0_congratulations.md
     action_id: publishIssue
-    comments:
-      - how-to-publish.md
+  - type: respond
+    issue: '%actions.publishIssue.data.title%'
+    with: how-to-publish.md
+    data: 
+      url: '%payload.repository.html_url%/fork'
   - type: respond
     with: goto-publish.md
     data:

--- a/config.yml
+++ b/config.yml
@@ -18,7 +18,6 @@ before:
 # 3. PR: Setup the learner's repo
 # 4. PR: Write the course steps
 # 5. Issue: Publish your course
-# Note: if the learner chooses to transfer their course immediately, there will be an issue inserted after PR#2 with those instructions
 
 steps:
 
@@ -42,14 +41,10 @@ steps:
       left: '%payload.action%'
       operator: ===
       right: assigned
-    - type: createIssue
-      title: Transfer your course
-      body: how-to-publish.md
-      action_id: transferIssue
     - type: respond
-      with: goto-transfer.md
-      data:
-        url: '%actions.transferIssue.data.html_url%'
+      with: how-to-publish.md
+    - type: respond
+      with: change-mind.md
   - type: createPullRequest
     title: Add a course title and description
     body: 01.0_add-title.md

--- a/config.yml
+++ b/config.yml
@@ -574,7 +574,7 @@ steps:
     body: 14.0_congratulations.md
     action_id: publishIssue
   - type: respond
-    issue: '%actions.publishIssue.data.title%'
+    issue: '%actions.publishIssue.data.number%'
     with: how-to-publish.md
     data: 
       url: '%payload.repository.html_url%/fork'

--- a/config.yml
+++ b/config.yml
@@ -14,55 +14,65 @@ before:
 
 # Repo artifacts:
 # 1. Issue: Welcome
-# 2. Issue: Transfer your course 
-#    -OR- 
 # 2. PR: Add a course title and description
 # 3. PR: Setup the learner's repo
 # 4. PR: Write the course steps
 # 5. Issue: Publish your course
+# Note: if the learner chooses to transfer their course immediately, there will be an issue inserted after PR#2 with those instructions
 
 steps:
 
 # 1
 - title: Welcome
   description: Decide whether to complete a guided course, or use boilerplate as is.
-  event: issues.closed
+  event: issues
   link: '{{ repoUrl }}/issues/1'
   actions:
   - type: gate
-    left: '%payload.issue.assignee%'
+    left: '%payload.issue.title%'
+    operator: ===
+    right: Welcome
+  - type: gate
+    left: '%payload.action%'
+    operator: ===
+    right: closed
+    required: false
     else:
-    - type: createPullRequest
-      title: Add a course title and description
-      body: 01.0_add-title.md
-      head: title
-      action_id: metaPR
-    - type: assignRegistrant
-      issue: '%actions.metaPR.data.number%'
-    - type: octokit
-      method: pullRequests.createComment
-      owner: '%actions.metaPR.data.head.repo.owner.login%'
-      repo: '%actions.metaPR.data.head.repo.name%'
-      number: '%actions.metaPR.data.number%'
-      commit_id: '%actions.metaPR.data.head.sha%'
-      path: config.yml
-      body: |
-        ```suggestion
-        title: My amazing course
-        ```
-      position: 6
+    - type: gate
+      left: '%payload.action%'
+      operator: ===
+      right: assigned
+    - type: createIssue
+      title: Transfer your course
+      body: how-to-publish.md
+      action_id: transferIssue
     - type: respond
-      with: goto-first-pr.md
+      with: goto-transfer.md
       data:
-        url: '%actions.metaPR.data.html_url%'
-  - type: createIssue
-    title: Transfer your course
-    body: how-to-publish.md
-    action_id: transferIssue
+        url: '%actions.transferIssue.data.html_url%'
+  - type: createPullRequest
+    title: Add a course title and description
+    body: 01.0_add-title.md
+    head: title
+    action_id: metaPR
+  - type: assignRegistrant
+    issue: '%actions.metaPR.data.number%'
+  - type: octokit
+    method: pullRequests.createComment
+    owner: '%actions.metaPR.data.head.repo.owner.login%'
+    repo: '%actions.metaPR.data.head.repo.name%'
+    number: '%actions.metaPR.data.number%'
+    commit_id: '%actions.metaPR.data.head.sha%'
+    path: config.yml
+    body: |
+      ```suggestion
+      title: My amazing course
+      ```
+    position: 6
   - type: respond
-    with: goto-transfer.md
+    with: goto-first-pr.md
     data:
-      url: '%actions.transferIssue.data.html_url%'
+      url: '%actions.metaPR.data.html_url%'
 
 # 2
 - title: Give your course a title

--- a/config.yml
+++ b/config.yml
@@ -39,9 +39,22 @@ steps:
 # 1
 - title: Give your course a title
   description: Name your course so learners can find it.
-  event: pull_request.synchronize
+  event: pull_request
   link: '{{ repoUrl }}/pull/1'
   actions:
+  - type: gate
+    left: '%payload.pull_request.action'
+    operator: ===
+    right: synchronize
+    else:
+    - type: gate
+      left: '%payload.pull_request.action%'
+      operator: ===
+      right: closed
+      required: false
+    - type: createIssue
+      title: Transfer your course
+      body: 14.0_congratulations.md
   - type: getFileContents
     action_id: fileContents
     filename: 'config.yml'

--- a/config.yml
+++ b/config.yml
@@ -13,10 +13,13 @@ before:
   - type: updateBranchProtection
 
 # Repo artifacts:
-# 1. PR: Add a course title and description
-# 2. PR: Setup the learner's repo
-# 3. PR: Write the course steps
-# 4. Issue: Publish your course
+# 1. Issue: Welcome
+# 2. Issue: Transfer your course 
+#    -OR- 
+# 2. PR: Add a course title and description
+# 3. PR: Setup the learner's repo
+# 4. PR: Write the course steps
+# 5. Issue: Publish your course
 
 steps:
 
@@ -54,14 +57,14 @@ steps:
         url: '%actions.metaPR.data.html_url%'
   - type: createIssue
     title: Transfer your course
-    body: 14.0_congratulations.md
+    body: how-to-publish.md
     action_id: transferIssue
   - type: respond
     with: goto-transfer.md
     data:
       url: '%actions.transferIssue.data.html_url%'
 
-# 1
+# 2
 - title: Give your course a title
   description: Name your course so learners can find it.
   event: pull_request.synchronize
@@ -104,7 +107,7 @@ steps:
       ```
     position: 8
 
-# 2
+# 3
 - title: Add some descriptions to your course
   description: Give your course a description and tagline so learners can identify it.
   link: '{{ repoUrl }}/pull/1'
@@ -124,7 +127,7 @@ steps:
   - type: respond
     with: approve-first-pr.md
 
-# 3
+# 4
 - title: Approve the course metadata
   description: Approve the pull request containing the course's metadata.
   link: '{{ repoUrl }}/pull/1'
@@ -159,7 +162,7 @@ steps:
       ```
     position: 7
 
-# 4
+# 5
 - title: Point to the template repo
   description: Designate a template repository from which to clone.
   link: '{{ repoUrl }}/pull/2'
@@ -190,7 +193,7 @@ steps:
       ```
     position: 6
 
-# 5
+# 6
 - title: Give the learner's repo a name
   description: Designate a name for the repository when it is created for the learner.
   link: '{{ repoUrl }}/pull/2'
@@ -210,7 +213,7 @@ steps:
   - type: respond
     with: approve-second-pr.md
 
-# 6
+# 7
 - title: Approve the repo setup
   description: Approve the template repo information
   link: '{{ repoUrl }}/pull/2'
@@ -269,7 +272,7 @@ steps:
       ```
     position: 9
 
-# 7
+# 8
 - title: Create an issue using Learning Lab
   description: Use the `before` block to create an issue in the learner's repo.
   link: '{{ repoUrl }}/pull/3'
@@ -290,7 +293,7 @@ steps:
     data:
       fileUrl: '%payload.repository.html_url%/new/%payload.pull_request.head.ref%/responses?filename=responses/welcome-text.md'
 
-# 8
+# 9
 - title: Create your first response
   description: Add content to the repo's first issue.
   link: '{{ repoUrl }}/pull/3'
@@ -344,7 +347,7 @@ steps:
       ```
     position: 20
 
-# 9
+# 10
 - title: Name your first step and give it a description
   description: Identify the first step so the learner knows what's expected.
   link: '{{ repoUrl }}/pull/3'
@@ -375,7 +378,7 @@ steps:
       ```
     position: 21
 
-# 10
+# 11
 - title: Trigger your first step with a GitHub event
   description: Add a pull_request.opened event.
   link: '{{ repoUrl }}/pull/3'
@@ -406,7 +409,7 @@ steps:
       ```
     position: 32
 
-# 11
+# 12
 - title: Validate a learner's PR
   description: Add a gate to determine if the learner took the expected action.
   link: '{{ repoUrl }}/pull/3'
@@ -461,7 +464,7 @@ steps:
       ```
     position: 35
 
-# 12
+# 13
 - title: Use contextual information to validate
   description: Add options to the gate action.
   link: '{{ repoUrl }}/pull/3'
@@ -506,7 +509,7 @@ steps:
       ```
     position: 37
 
-# 13
+# 14
 - title: Respond to a learner's successful PR
   description: Use a respond action when a learner opens their pull request.
   link: '{{ repoUrl }}/pull/3'
@@ -527,7 +530,7 @@ steps:
     data:
       fileUrl: '%payload.repository.html_url%/new/%payload.pull_request.head.ref%?filename=README.md'
 
-# 14
+# 15
 - title: Add a README to your course
   description: Write a longform description for your course.
   link: '{{ repoUrl }}/pull/3'
@@ -548,7 +551,7 @@ steps:
   - type: respond
     with: 13.0_publish.md
 
-# 15
+# 16
 - title: Approve the steps
   description: Submit an approval for the steps pull request.
   link: '{{ repoUrl }}/pull/3'
@@ -563,6 +566,8 @@ steps:
     title: Publish your course
     body: 14.0_congratulations.md
     action_id: publishIssue
+    comments:
+      - how-to-publish.md
   - type: respond
     with: goto-publish.md
     data:

--- a/config.yml
+++ b/config.yml
@@ -5,27 +5,11 @@ template:
   name: lab-starter
   repo: write-a-ll-course-template
 before:
-  - type: createPullRequest
-    title: Add a course title and description
+  - type: createIssue
+    title: Welcome
     body: 00.0_welcome.md
-    head: title
     comments:
-      - 01.0_add-title.md
-    action_id: metaPR
-  - type: assignRegistrant
-    issue: '%actions.metaPR.data.number%'
-  - type: octokit
-    method: pullRequests.createComment
-    owner: '%actions.metaPR.data.head.repo.owner.login%'
-    repo: '%actions.metaPR.data.head.repo.name%'
-    number: '%actions.metaPR.data.number%'
-    commit_id: '%actions.metaPR.data.head.sha%'
-    path: config.yml
-    body: |
-      ```suggestion
-      title: My amazing course
-      ```
-    position: 6
+      - welcome-2.md
   - type: updateBranchProtection
 
 # Repo artifacts:
@@ -37,24 +21,45 @@ before:
 steps:
 
 # 1
-- title: Give your course a title
-  description: Name your course so learners can find it.
-  event: pull_request
-  link: '{{ repoUrl }}/pull/1'
+- title: Welcome
+  description: Decide whether to complete a guided course, or use boilerplate as is.
+  event: issues.closed
+  link: '{{ repoUrl }}/issues/1'
   actions:
   - type: gate
-    left: '%payload.pull_request.action'
-    operator: ===
-    right: synchronize
+    left: '%payload.issue.assignee%'
     else:
-    - type: gate
-      left: '%payload.pull_request.action%'
-      operator: ===
-      right: closed
-      required: false
-    - type: createIssue
-      title: Transfer your course
-      body: 14.0_congratulations.md
+    - type: createPullRequest
+      title: Add a course title and description
+      body: 00.0_welcome.md
+      head: title
+      comments:
+        - 01.0_add-title.md
+      action_id: metaPR
+    - type: assignRegistrant
+      issue: '%actions.metaPR.data.number%'
+    - type: octokit
+      method: pullRequests.createComment
+      owner: '%actions.metaPR.data.head.repo.owner.login%'
+      repo: '%actions.metaPR.data.head.repo.name%'
+      number: '%actions.metaPR.data.number%'
+      commit_id: '%actions.metaPR.data.head.sha%'
+      path: config.yml
+      body: |
+        ```suggestion
+        title: My amazing course
+        ```
+      position: 6
+  - type: createIssue
+    title: Transfer your course
+    body: 14.0_congratulations.md      
+
+# 1
+- title: Give your course a title
+  description: Name your course so learners can find it.
+  event: pull_request.synchronize
+  link: '{{ repoUrl }}/pull/1'
+  actions:
   - type: getFileContents
     action_id: fileContents
     filename: 'config.yml'

--- a/config.yml
+++ b/config.yml
@@ -31,10 +31,8 @@ steps:
     else:
     - type: createPullRequest
       title: Add a course title and description
-      body: 00.0_welcome.md
+      body: 01.0_add-title.md
       head: title
-      comments:
-        - 01.0_add-title.md
       action_id: metaPR
     - type: assignRegistrant
       issue: '%actions.metaPR.data.number%'
@@ -50,9 +48,18 @@ steps:
         title: My amazing course
         ```
       position: 6
+    - type: respond
+      with: goto-first-pr.md
+      data:
+        url: '%actions.metaPR.data.html_url%'
   - type: createIssue
     title: Transfer your course
-    body: 14.0_congratulations.md      
+    body: 14.0_congratulations.md
+    action_id: transferIssue
+  - type: respond
+    with: goto-transfer.md
+    data:
+      url: '%actions.transferIssue.data.html_url%'
 
 # 1
 - title: Give your course a title

--- a/responses/00.0_welcome.md
+++ b/responses/00.0_welcome.md
@@ -2,15 +2,7 @@
 
 :running_woman: If you look around this repository, you'll find a few standard template files in your Code tab. These contain most of what you need to get a Learning Lab course up and running. You can take this code as-is and create a Learning Lab course on your own. 
 
-- For a fully guided course writing experience, continue with this PR! 
-- If you'd like to work on your own, close this pull request and we'll provide instructions on how to transfer the course to your own organization.
+### How do you prefer to work? 
 
-### Documentation 
-
-:book: The official [Learning Lab docs](https://github.github.com/learning-lab-equipment/#/) contain full instructions on how to create courses. We'll link to the docs throughout the course. Take a look if you'd like more information about steps we take in this course.
-
-### New to GitHub?
-
-For this course, you'll need to know how to create a branch on GitHub, commit changes using Git, and open a pull request on GitHub. If you need a refresher on the GitHub flow, check out [the Introduction to GitHub course]({{ host}}/courses/introduction-to-github).
-
-You'll also need a general understanding of webhooks and the GitHub API.  [The Getting started with GitHub Apps course]({{ host}}/courses/getting-started-with-github-apps) is a good place to start.
+- :octocat: For a fully guided course writing experience, close this issue.
+- :car: If you'd like to work on your own, assign this issue to yourself and then close it. We'll provide instructions on how to transfer the course to your own organization.

--- a/responses/00.0_welcome.md
+++ b/responses/00.0_welcome.md
@@ -5,4 +5,4 @@
 ### How do you prefer to work? 
 
 - :octocat: For a fully guided course writing experience, close this issue.
-- :car: If you'd like to work on your own, assign this issue to yourself and then close it. We'll provide instructions on how to transfer the course to your own organization.
+- :car: If you'd like to work on your own, assign this issue to yourself.

--- a/responses/00.0_welcome.md
+++ b/responses/00.0_welcome.md
@@ -1,6 +1,11 @@
 # Welcome!
 
-:running_woman: If you look around this repository, you'll find a few standard template files in your Code tab. These contain most of what you need to get a Learning Lab course up and running. You can take this code as-is and create a Learning Lab course on your own. If you'd like some guidance, continue taking this course!
+:running_woman: If you look around this repository, you'll find a few standard template files in your Code tab. These contain most of what you need to get a Learning Lab course up and running. You can take this code as-is and create a Learning Lab course on your own. 
+
+- For a fully guided course writing experience, continue with this PR! 
+- If you'd like to work on your own, close this pull request and we'll provide instructions on how to transfer the course to your own organization.
+
+### Documentation 
 
 :book: The official [Learning Lab docs](https://github.github.com/learning-lab-equipment/#/) contain full instructions on how to create courses. We'll link to the docs throughout the course. Take a look if you'd like more information about steps we take in this course.
 

--- a/responses/14.0_congratulations.md
+++ b/responses/14.0_congratulations.md
@@ -1,11 +1,15 @@
 ## Nice work!
 
-Now that your changes are on `master`, you're ready to publish the course.
+You're ready to publish the course. Since Learning Lab courses must be owned by your organization, you'll need to [fork](https://help.github.com/articles/fork-a-repo/) the courses there first. Here are the instructions:
 
 ## Publish the course
-1. Confirm that you are an owner of the **{{ owner }}** organization, or a member of a team named **lab-assistants** in the **{{ owner }}** organization.
-1. Navigate to https://lab-sandbox.github.com/{{ owner }}/new.
+1. Choose an organization that will house your Learning Lab courses. You may have done this prior to taking the course.
+1. Confirm that you are an owner of the chosen Learning Lab course organization, or a member of a team named **lab-assistants** in that organization.
+1. Fork this repository to your chosen organization.
+1. Fork the template repository to your chosen organization.
+1. Navigate to https://lab-sandbox.github.com/`your-organization`/new.
 1. In the Repository name field, type in **{{ repo }}**
 1. We recommend selecting **Private** so you can test the course with other members of the organization before making it public.
+1. Take the course, which should be available at https://lab-sandbox.github.com/`your-organization`/{{ repo }}
 
 Now...[what will you learn next]({{ host }}/courses)?

--- a/responses/14.0_congratulations.md
+++ b/responses/14.0_congratulations.md
@@ -1,15 +1,3 @@
 ## Nice work!
 
-You're ready to publish the course. Since Learning Lab courses must be owned by your organization, you'll need to [fork](https://help.github.com/articles/fork-a-repo/) the courses there first. Here are the instructions:
-
-## Publish the course
-1. Choose an organization that will house your Learning Lab courses. You may have done this prior to taking the course.
-1. Confirm that you are an owner of the chosen Learning Lab course organization, or a member of a team named **lab-assistants** in that organization.
-1. Fork this repository to your chosen organization.
-1. Fork the template repository to your chosen organization.
-1. Navigate to https://lab-sandbox.github.com/`your-organization`/new.
-1. In the Repository name field, type in **{{ repo }}**
-1. We recommend selecting **Private** so you can test the course with other members of the organization before making it public.
-1. Take the course, which should be available at https://lab-sandbox.github.com/`your-organization`/{{ repo }}
-
-Now...[what will you learn next]({{ host }}/courses)?
+You're ready to publish the course. 

--- a/responses/change-mind.md
+++ b/responses/change-mind.md
@@ -1,0 +1,1 @@
+We'll continue the course instructions in case you change your mind and would like to continue. If you do, just return to this issue to pick it up where you left off. 

--- a/responses/goto-first-pr.md
+++ b/responses/goto-first-pr.md
@@ -1,0 +1,1 @@
+Let's go to the [first PR]({{ url }}) which I've opened for you. 

--- a/responses/goto-transfer.md
+++ b/responses/goto-transfer.md
@@ -1,0 +1,1 @@
+Let's take a look at some [instructions for transferring this repo]({{ url }}).

--- a/responses/how-to-publish.md
+++ b/responses/how-to-publish.md
@@ -1,0 +1,11 @@
+Since Learning Lab courses must be owned by your organization, you'll need to [fork](https://help.github.com/articles/fork-a-repo/) the courses there first. Here are the instructions:
+
+## Publish the course
+1. Choose an organization that will house your Learning Lab courses. You may have done this prior to taking the course.
+1. Confirm that you are an owner of the chosen Learning Lab course organization, or a member of a team named **lab-assistants** in that organization.
+1. Fork this repository to your chosen organization.
+1. Fork the template repository to your chosen organization.
+1. Navigate to `https://lab-sandbox.github.com/YOUR-ORGANIZATION/new`
+1. In the Repository name field, type in **{{ repo }}**
+1. We recommend selecting **Private** so you can test the course with other members of the organization before making it public.
+1. Take the course, which should be available at https://lab-sandbox.github.com/YOUR-ORGANIZATION/{{ repo }}

--- a/responses/how-to-publish.md
+++ b/responses/how-to-publish.md
@@ -1,10 +1,10 @@
-Since Learning Lab courses must be owned by your organization, you'll need to [fork](https://help.github.com/articles/fork-a-repo/) the courses there first. Here are the instructions:
+Since Learning Lab courses must be owned by your organization, you'll need to [fork](https://help.github.com/articles/fork-a-repo/) the course and template repositories there first. Here are the instructions:
 
 ## Publish the course
 1. Choose an organization that will house your Learning Lab courses. You may have done this prior to taking the course.
 1. Confirm that you are an owner of the chosen Learning Lab course organization, or a member of a team named **lab-assistants** in that organization.
-1. Fork this repository to your chosen organization.
-1. Fork the template repository to your chosen organization.
+1. [Fork this repository]({{ url }}) to your chosen organization.
+1. [Fork the template repository](https://github.com/githubtraining/lab-starter-template/fork) to your chosen organization.
 1. Navigate to `https://lab-sandbox.github.com/YOUR-ORGANIZATION/new`
 1. In the Repository name field, type in **{{ repo }}**
 1. We recommend selecting **Private** so you can test the course with other members of the organization before making it public.

--- a/responses/welcome-2.md
+++ b/responses/welcome-2.md
@@ -1,0 +1,9 @@
+### Documentation 
+
+:book: The official [Learning Lab docs](https://github.github.com/learning-lab-equipment/#/) contain full instructions on how to create courses. We'll link to the docs throughout the course. Take a look if you'd like more information about steps we take in this course.
+
+### New to GitHub?
+
+For this course, you'll need to know how to create a branch on GitHub, commit changes using Git, and open a pull request on GitHub. If you need a refresher on the GitHub flow, check out [the Introduction to GitHub course]({{ host}}/courses/introduction-to-github).
+
+You'll also need a general understanding of webhooks and the GitHub API.  [The Getting started with GitHub Apps course]({{ host}}/courses/getting-started-with-github-apps) is a good place to start.


### PR DESCRIPTION
With the first iteration of this course, I assumed that the course would be created inside of the organization that wished to create a new course. Instead, this course will realistically be owned by @githubtraining, so the instructions need to change to walk the learner through moving their course and template repos into their own org.

I will leave this open until I have a chance to thoroughly test it tomorrow. If anyone else has the bandwidth to, I'd appreciate it. 